### PR TITLE
web_socket_support_platform_interface 0.2.0 (null safety)

### DIFF
--- a/web_socket_support/web_socket_support/lib/web_socket_support.dart
+++ b/web_socket_support/web_socket_support/lib/web_socket_support.dart
@@ -9,14 +9,14 @@ import 'package:web_socket_support_platform_interface/web_socket_listener.dart';
 import 'package:web_socket_support_platform_interface/web_socket_options.dart';
 import 'package:web_socket_support_platform_interface/web_socket_support_platform_interface.dart';
 
+export 'package:web_socket_support_platform_interface/web_scoket_exception.dart'
+    show WebSocketException;
+export 'package:web_socket_support_platform_interface/web_socket_connection.dart'
+    show WebSocketConnection;
 // Export necessary Classes from the platform_interface and this implementation
 // so plugin users can use them directly.
 export 'package:web_socket_support_platform_interface/web_socket_listener.dart'
     show WebSocketListener;
-export 'package:web_socket_support_platform_interface/web_socket_connection.dart'
-    show WebSocketConnection;
-export 'package:web_socket_support_platform_interface/web_scoket_exception.dart'
-    show WebSocketException;
 
 class WebSocketClient extends WebSocketSupportPlatform {
   /// constructor
@@ -29,6 +29,7 @@ class WebSocketClient extends WebSocketSupportPlatform {
             ' which is not DummyWebSocketListener.',
       );
     }
+    // init correct platform isntance
     WebSocketSupportPlatform.instance = MethodChannelWebSocketSupport(listener);
   }
 

--- a/web_socket_support/web_socket_support_platform_interface/CHANGELOG.md
+++ b/web_socket_support/web_socket_support_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+* Moved to null safety. Min SDK is 2.14.0
+
 ## 0.1.6
 
 * Updated dependencies after Flutter 2.0 release.

--- a/web_socket_support/web_socket_support_platform_interface/lib/web_scoket_exception.dart
+++ b/web_socket_support/web_socket_support_platform_interface/lib/web_scoket_exception.dart
@@ -1,6 +1,4 @@
-import 'dart:io';
-
-class WebSocketException implements IOException {
+class WebSocketException implements Exception {
   final String originType;
   final String message;
   final String causeMessage;

--- a/web_socket_support/web_socket_support_platform_interface/lib/web_socket_connection.dart
+++ b/web_socket_support/web_socket_support_platform_interface/lib/web_socket_connection.dart
@@ -6,10 +6,10 @@ import 'package:flutter/services.dart';
 /// WebSocket connection initialized by [connect] call.
 abstract class WebSocketConnection {
   /// Call this method when you want to send Text message to server.
-  Future<bool> sendTextMessage(String message);
+  Future<bool?> sendStringMessage(String message);
 
   /// Call this method when you want to send Byte message to server.
-  Future<bool> sendByteMessage(Uint8List message);
+  Future<bool?> sendByteArrayMessage(Uint8List message);
 }
 
 class DefaultWebSocketConnection implements WebSocketConnection {
@@ -18,16 +18,13 @@ class DefaultWebSocketConnection implements WebSocketConnection {
   DefaultWebSocketConnection(this._methodChannel);
 
   @override
-  Future<bool> sendByteMessage(Uint8List message) {
-    return _methodChannel.invokeMethod('sendByteMessage', {
-      'byteMessage': message,
-    });
+  Future<bool?> sendStringMessage(String stringMessage) {
+    return _methodChannel.invokeMethod('sendStringMessage', stringMessage);
   }
 
   @override
-  Future<bool> sendTextMessage(String message) {
-    return _methodChannel.invokeMethod('sendTextMessage', {
-      'textMessage': message,
-    });
+  Future<bool?> sendByteArrayMessage(Uint8List byteArrayMessage) {
+    return _methodChannel.invokeMethod(
+        'sendByteArrayMessage', byteArrayMessage);
   }
 }

--- a/web_socket_support/web_socket_support_platform_interface/lib/web_socket_listener.dart
+++ b/web_socket_support/web_socket_support_platform_interface/lib/web_socket_listener.dart
@@ -22,10 +22,10 @@ abstract class WebSocketListener {
   void onWsClosed(int code, String reason);
 
   /// Invoked when a text (type `0x1`) message has been received.
-  void onTextMessage(String message);
+  void onStringMessage(String message);
 
   /// Invoked when a binary (type `0x2`) message has been received.
-  void onByteMessage(Uint8List message);
+  void onByteArrayMessage(Uint8List message);
 
   /// Invoked when error occurs in transport between dart and platform.
   void onError(Exception exception);

--- a/web_socket_support/web_socket_support_platform_interface/lib/web_socket_support_platform_interface.dart
+++ b/web_socket_support/web_socket_support_platform_interface/lib/web_socket_support_platform_interface.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:typed_data';
 
-import 'package:meta/meta.dart' show required;
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:web_socket_support_platform_interface/method_channel_web_socket_support.dart';
 import 'package:web_socket_support_platform_interface/web_socket_connection.dart';
@@ -15,7 +14,7 @@ import 'package:web_socket_support_platform_interface/web_socket_options.dart';
 /// (using `extends`) ensures that the subclass will get the default implementation, while
 /// platform implementations that `implements` this interface will be broken by newly added
 /// [WebSocketSupportPlatform] methods.
-class WebSocketSupportPlatform extends PlatformInterface {
+abstract class WebSocketSupportPlatform extends PlatformInterface {
   ///
   /// Constructs a WebSocketSupportPlatform.
   WebSocketSupportPlatform() : super(token: _token);
@@ -42,7 +41,7 @@ class WebSocketSupportPlatform extends PlatformInterface {
   /// If connection was successful, [onWsOpened] will be invoked.
   Future<void> connect(
     String serverUrl, {
-    @required WebSocketOptions options,
+    WebSocketOptions options = const WebSocketOptions(),
   }) {
     throw UnimplementedError('connect() has not been implemented.');
   }
@@ -65,7 +64,7 @@ class DummyWebSocketListener extends WebSocketListener {
   DummyWebSocketListener._();
 
   @override
-  void onByteMessage(Uint8List message) {
+  void onByteArrayMessage(Uint8List message) {
     print('Byte message received. Size: ${message.length}');
   }
 
@@ -75,7 +74,7 @@ class DummyWebSocketListener extends WebSocketListener {
   }
 
   @override
-  void onTextMessage(String message) {
+  void onStringMessage(String message) {
     print('Text message received. Content: $message');
   }
 

--- a/web_socket_support/web_socket_support_platform_interface/lib/web_socket_support_platform_interface.dart
+++ b/web_socket_support/web_socket_support_platform_interface/lib/web_socket_support_platform_interface.dart
@@ -65,31 +65,37 @@ class DummyWebSocketListener extends WebSocketListener {
 
   @override
   void onByteArrayMessage(Uint8List message) {
-    print('Byte message received. Size: ${message.length}');
+    throw UnimplementedError(
+        'onByteArrayMessage(Uint8List message) has not been implemented.');
   }
 
   @override
   void onError(Exception exception) {
-    print('Platform exception occurred: $exception');
+    throw UnimplementedError(
+        'onError(Exception exception) has not been implemented.');
   }
 
   @override
   void onStringMessage(String message) {
-    print('Text message received. Content: $message');
+    throw UnimplementedError(
+        'onStringMessage(String message) has not been implemented.');
   }
 
   @override
   void onWsClosed(int code, String reason) {
-    print('WebSocket connection closed. Code:$code, Reason:$reason:');
+    throw UnimplementedError(
+        'onWsClosed(int code, String reason) has not been implemented.');
   }
 
   @override
   void onWsClosing(int code, String reason) {
-    print('WebSocket connection is closing. Code:$code, Reason:$reason:');
+    throw UnimplementedError(
+        'onWsClosing(int code, String reason) has not been implemented.');
   }
 
   @override
   void onWsOpened(WebSocketConnection webSocketConnection) {
-    print('WebSocket connection opened. Ws:$webSocketConnection');
+    throw UnimplementedError(
+        'onWsOpened(WebSocketConnection webSocketConnection) has not been implemented.');
   }
 }

--- a/web_socket_support/web_socket_support_platform_interface/pubspec.yaml
+++ b/web_socket_support/web_socket_support_platform_interface/pubspec.yaml
@@ -1,16 +1,16 @@
 name: web_socket_support_platform_interface
 description: A common platform interface for the web_socket_support plugin.
 homepage: https://github.com/sharpbitstudio/flutter-plugins/tree/master/web_socket_support/web_socket_support_platform_interface
-version: 0.1.6
+version: 0.2.0
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
-  flutter: ">=1.20.0"
+  sdk: ">=2.14.0 <3.0.0"
+  flutter: ">=2.5.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  async: ^2.5.0
+  async: ^2.8.1
   meta: ^1.3.0
   plugin_platform_interface: ^2.0.0
 

--- a/web_socket_support/web_socket_support_platform_interface/test/event_channel_mock.dart
+++ b/web_socket_support/web_socket_support_platform_interface/test/event_channel_mock.dart
@@ -1,0 +1,90 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class EventChannelMock {
+  final MethodChannel _methodChannel;
+  final log = <MethodCall>[];
+
+  Stream? stream;
+  StreamSubscription? _streamSubscription;
+
+  EventChannelMock({
+    required String channelName,
+    required this.stream,
+  }) : _methodChannel = MethodChannel(channelName) {
+    TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
+        .setMockMethodCallHandler(_methodChannel, _handler);
+  }
+
+  Future _handler(MethodCall methodCall) {
+    log.add(methodCall);
+
+    switch (methodCall.method) {
+      case 'listen':
+        _onListen();
+        break;
+      case 'cancel':
+        _onCancel();
+        break;
+      default:
+        return Future.value(null);
+    }
+
+    return Future.value();
+  }
+
+  void _onListen() {
+    _streamSubscription = stream!.handleError((e) {
+      _sendErrorEnvelope(e);
+    }).listen(
+      _sendSuccessEnvelope,
+      onDone: () {
+        _sendEnvelope(null);
+      },
+    );
+  }
+
+  void _onCancel() {
+    if (_streamSubscription != null) {
+      _streamSubscription!.cancel();
+      stream = null;
+    }
+  }
+
+  void _sendErrorEnvelope(Exception error) {
+    var code = 'UNKNOWN_EXCEPTION';
+    String? message;
+    dynamic details;
+
+    if (error is PlatformException) {
+      code = error.code;
+      message = error.message;
+      details = error.details;
+    }
+
+    final envelope = const StandardMethodCodec()
+        .encodeErrorEnvelope(code: code, message: message, details: details);
+
+    _sendEnvelope(envelope);
+  }
+
+  void _sendSuccessEnvelope(dynamic event) {
+    final envelope = const StandardMethodCodec().encodeSuccessEnvelope(event);
+    _sendEnvelope(envelope);
+  }
+
+  void _sendEnvelope(ByteData? envelope) {
+    if (TestDefaultBinaryMessengerBinding.instance == null) {
+      return;
+    }
+
+    TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
+        .handlePlatformMessage(
+      _methodChannel.name,
+      envelope,
+      (_) {},
+    );
+  }
+}

--- a/web_socket_support/web_socket_support_platform_interface/test/method_channel_mock.dart
+++ b/web_socket_support/web_socket_support_platform_interface/test/method_channel_mock.dart
@@ -1,0 +1,60 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class MethodChannelMock {
+  final Duration delay;
+  final MethodChannel methodChannel;
+  final List<MethodMock> methodMocks;
+  final log = <MethodCall>[];
+
+  MethodChannelMock({
+    required String channelName,
+    this.delay = Duration.zero,
+    required this.methodMocks,
+  }) : methodChannel = MethodChannel(channelName) {
+    TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
+        .setMockMethodCallHandler(methodChannel, _handler);
+  }
+
+  Future _handler(MethodCall methodCall) async {
+    log.add(methodCall);
+
+    if (!methodMocks.map((e) => e.method).contains(methodCall.method)) {
+      throw MissingPluginException('No implementation found for method '
+          '${methodCall.method} on channel ${methodChannel.name}');
+    }
+
+    final methodMock =
+        methodMocks.where((e) => e.method == methodCall.method).first;
+
+    return Future.delayed(delay, () {
+      // throw exception if defined as a result
+      if (methodMock.result is Exception) {
+        throw methodMock.result;
+      }
+
+      // execute action callback
+      Future.delayed(Duration.zero, methodMock.action());
+
+      // return result
+      return Future.value(methodMock.result);
+    });
+  }
+
+  void sendPlatformMessage(MethodCall methodCall) {
+    final envelope = const StandardMethodCodec().encodeMethodCall(methodCall);
+    TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
+        .handlePlatformMessage(methodChannel.name, envelope, (data) {});
+  }
+}
+
+class MethodMock {
+  final String method;
+  final dynamic result;
+  final Function() action;
+
+  MethodMock({required this.method, this.result, this.action = _defaultAction});
+  static void _defaultAction() {}
+}

--- a/web_socket_support/web_socket_support_platform_interface/test/method_channel_web_socket_support_test.dart
+++ b/web_socket_support/web_socket_support_platform_interface/test/method_channel_web_socket_support_test.dart
@@ -286,7 +286,7 @@ void main() {
       await _testWsListener.destroy();
     });
 
-    test('Receive event from platform on textEventChannel', () async {
+    test('Receive event from platform via textEventChannel', () async {
       final _testWsListener = TestWebSocketListener();
       MethodChannelWebSocketSupport(_testWsListener);
 
@@ -316,7 +316,44 @@ void main() {
       await _testWsListener.destroy();
     });
 
-    test('Receive event from platform on byteEventChannel', () async {
+    test('Receive error event from platform via textEventChannel', () async {
+      final _testWsListener = TestWebSocketListener();
+      MethodChannelWebSocketSupport(_testWsListener);
+
+      // prepare
+      // text message channel mock (before we is opened)
+      final _streamController = StreamController<String>.broadcast();
+      EventChannelMock(
+        channelName: MethodChannelWebSocketSupport.textEventChannelName,
+        stream: _streamController.stream,
+      );
+
+      // open ws
+      await _sendMessageFromPlatform(
+          MethodChannelWebSocketSupport.methodChannelName,
+          MethodCall('onOpened'));
+
+      // action
+      // emit test error event
+      _streamController.addError(
+        PlatformException(
+            code: 'ERROR_CODE_3', message: 'errMsg3', details: null),
+      );
+
+      // verify
+      expect(_testWsListener.webSocketConnection, isNotNull);
+
+      await _testWsListener.errorCompleter.future.timeout(Duration(seconds: 1));
+      expect(_testWsListener.onErrorCalled, true);
+      expect(_testWsListener.exception, isInstanceOf<PlatformException>());
+      expect(_testWsListener.exception.toString(),
+          'PlatformException(ERROR_CODE_3, errMsg3, null, null)');
+
+      // clean up
+      await _testWsListener.destroy();
+    });
+
+    test('Receive event from platform via byteEventChannel', () async {
       final _testWsListener = TestWebSocketListener();
       MethodChannelWebSocketSupport(_testWsListener);
 
@@ -346,7 +383,44 @@ void main() {
       await _testWsListener.destroy();
     });
 
-    test('Receive `onStringMessage` event after ws is established', () async {
+    test('Receive error event from platform via byteEventChannel', () async {
+      final _testWsListener = TestWebSocketListener();
+      MethodChannelWebSocketSupport(_testWsListener);
+
+      // prepare
+      // text message channel mock (before we is opened)
+      final _streamController = StreamController<Uint8List>.broadcast();
+      EventChannelMock(
+        channelName: MethodChannelWebSocketSupport.byteEventChannelName,
+        stream: _streamController.stream,
+      );
+
+      // open ws
+      await _sendMessageFromPlatform(
+          MethodChannelWebSocketSupport.methodChannelName,
+          MethodCall('onOpened'));
+
+      // action
+      // emit error test event
+      _streamController.addError(
+        PlatformException(
+            code: 'ERROR_CODE_4', message: 'errMsg4', details: null),
+      );
+
+      // verify
+      expect(_testWsListener.webSocketConnection, isNotNull);
+
+      await _testWsListener.errorCompleter.future.timeout(Duration(seconds: 1));
+      expect(_testWsListener.onErrorCalled, true);
+      expect(_testWsListener.exception, isInstanceOf<PlatformException>());
+      expect(_testWsListener.exception.toString(),
+          'PlatformException(ERROR_CODE_4, errMsg4, null, null)');
+
+      // clean up
+      await _testWsListener.destroy();
+    });
+
+    test('Receive `onStringMessage` event via MethodChannel', () async {
       final _testWsListener = TestWebSocketListener();
       MethodChannelWebSocketSupport(_testWsListener);
 
@@ -370,8 +444,7 @@ void main() {
       await _testWsListener.destroy();
     });
 
-    test('Receive `onByteArrayMessage` event after ws is established',
-        () async {
+    test('Receive `onByteArrayMessage` event via MethodChannel', () async {
       final _testWsListener = TestWebSocketListener();
       MethodChannelWebSocketSupport(_testWsListener);
 

--- a/web_socket_support/web_socket_support_platform_interface/test/method_channel_web_socket_support_test.dart
+++ b/web_socket_support/web_socket_support_platform_interface/test/method_channel_web_socket_support_test.dart
@@ -1,0 +1,406 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:web_socket_support_platform_interface/method_channel_web_socket_support.dart';
+import 'package:web_socket_support_platform_interface/web_scoket_exception.dart';
+import 'package:web_socket_support_platform_interface/web_socket_options.dart';
+
+import 'event_channel_mock.dart';
+import 'method_channel_mock.dart';
+import 'test_web_socket_listener.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // MethodChannel calls
+  final calledMethodsLog = <MethodCall>[];
+
+  // clear log before any test
+  setUp(() => calledMethodsLog.clear());
+
+  group('$MethodChannelWebSocketSupport calls TO platform', () {
+    test('Send `connect` event before we is established', () async {
+      final _testWsListener = TestWebSocketListener();
+      final _webSocketSupport = MethodChannelWebSocketSupport(_testWsListener);
+
+      // Arrange
+      final _completer = Completer();
+      final _methodChannel = MethodChannelMock(
+        channelName: MethodChannelWebSocketSupport.methodChannelName,
+        methodMocks: [
+          MethodMock(
+              method: 'connect',
+              action: () {
+                _sendMessageFromPlatform(
+                    MethodChannelWebSocketSupport.methodChannelName,
+                    MethodCall('onOpened'));
+                _completer.complete();
+              }),
+        ],
+      );
+
+      // Act
+      await _webSocketSupport.connect('ws://example.com/',
+          options: WebSocketOptions(
+            autoReconnect: true,
+          ));
+
+      // await completer
+      await _completer.future;
+
+      // Assert
+      // correct event sent to platform
+      expect(
+        _methodChannel.log,
+        <Matcher>[
+          isMethodCall('connect', arguments: <String, Object>{
+            'serverUrl': 'ws://example.com/',
+            'options': {
+              'autoReconnect': true,
+              'pingInterval': 0,
+              'headers': {},
+            },
+          }),
+        ],
+      );
+
+      // platform response 'onOpened' created wsConnection
+      expect(_testWsListener.webSocketConnection, isNotNull);
+
+      // clean up
+      await _testWsListener.destroy();
+    });
+
+    test('Send `text` message after ws is established', () async {
+      final _testWsListener = TestWebSocketListener();
+      MethodChannelWebSocketSupport(_testWsListener);
+
+      // Arrange
+      // open ws
+      await _sendMessageFromPlatform(
+          MethodChannelWebSocketSupport.methodChannelName,
+          MethodCall('onOpened'));
+
+      // method channel mock
+      final _methodChannel = MethodChannelMock(
+        channelName: MethodChannelWebSocketSupport.methodChannelName,
+        methodMocks: [
+          MethodMock(
+            method: 'sendStringMessage',
+            result: true,
+          ),
+        ],
+      );
+
+      // Act - send text message
+      await _testWsListener.webSocketConnection!
+          .sendStringMessage('test payload 1');
+
+      // Assert
+      // correct event sent to platform
+      expect(
+        _methodChannel.log,
+        <Matcher>[
+          isMethodCall('sendStringMessage', arguments: 'test payload 1'),
+        ],
+      );
+
+      // clean up
+      await _testWsListener.destroy();
+    });
+
+    test('Send `binary` message after ws is established', () async {
+      final _testWsListener = TestWebSocketListener();
+      MethodChannelWebSocketSupport(_testWsListener);
+
+      // Arrange
+      // open ws
+      await _sendMessageFromPlatform(
+          MethodChannelWebSocketSupport.methodChannelName,
+          MethodCall('onOpened'));
+
+      // method channel mock
+      final _methodChannel = MethodChannelMock(
+        channelName: MethodChannelWebSocketSupport.methodChannelName,
+        methodMocks: [
+          MethodMock(
+            method: 'sendByteArrayMessage',
+            result: true,
+          ),
+        ],
+      );
+
+      // Act - send text message
+      await _testWsListener.webSocketConnection!
+          .sendByteArrayMessage(Uint8List.fromList('test payload 2'.codeUnits));
+
+      // Assert
+      // correct event sent to platform
+      expect(
+        _methodChannel.log,
+        <Matcher>[
+          isMethodCall('sendByteArrayMessage',
+              arguments: 'test payload 2'.codeUnits),
+        ],
+      );
+
+      // clean up
+      await _testWsListener.destroy();
+    });
+
+    test('Send `disconnect` event after we is established', () async {
+      final _testWsListener = TestWebSocketListener();
+      final _webSocketSupport = MethodChannelWebSocketSupport(_testWsListener);
+
+      // Arrange
+      // open ws
+      await _sendMessageFromPlatform(
+          MethodChannelWebSocketSupport.methodChannelName,
+          MethodCall('onOpened'));
+
+      final _completer = Completer();
+      final _methodChannel = MethodChannelMock(
+        channelName: MethodChannelWebSocketSupport.methodChannelName,
+        methodMocks: [
+          MethodMock(
+              method: 'disconnect',
+              action: () {
+                _sendMessageFromPlatform(
+                    MethodChannelWebSocketSupport.methodChannelName,
+                    MethodCall('onClosed', <String, Object>{
+                      'code': 123,
+                      'reason': 'test reason'
+                    }));
+                _completer.complete();
+              }),
+        ],
+      );
+
+      // Act -> disconnect
+      await _webSocketSupport.disconnect(code: 123, reason: 'test reason');
+
+      // await completer
+      await _completer.future;
+
+      // Assert
+      // correct event sent to platform
+      expect(
+        _methodChannel.log,
+        <Matcher>[
+          isMethodCall('disconnect', arguments: <String, Object>{
+            'code': 123,
+            'reason': 'test reason',
+          }),
+        ],
+      );
+
+      // platform response 'onOpened' created wsConnection
+      expect(_testWsListener.webSocketConnection, isNotNull);
+
+      // clean up
+      await _testWsListener.destroy();
+    });
+  });
+
+  group('$MethodChannelWebSocketSupport calls FROM platform', () {
+    test('Receive `onOpened` event from platform', () async {
+      final _testWsListener = TestWebSocketListener();
+      MethodChannelWebSocketSupport(_testWsListener);
+
+      // action
+      // execute methodCall from platform
+      await _sendMessageFromPlatform(
+          MethodChannelWebSocketSupport.methodChannelName,
+          MethodCall('onOpened'));
+
+      // verify
+      expect(_testWsListener.webSocketConnection, isNotNull);
+
+      // clean up
+      await _testWsListener.destroy();
+    });
+
+    test('Receive `onClosing` event from platform', () async {
+      final _testWsListener = TestWebSocketListener();
+      MethodChannelWebSocketSupport(_testWsListener);
+
+      // action
+      // execute methodCall from platform
+      await _sendMessageFromPlatform(
+          MethodChannelWebSocketSupport.methodChannelName,
+          MethodCall('onClosing',
+              <String, Object>{'code': 234, 'reason': 'test reason 2'}));
+
+      // verify
+      expect(_testWsListener.onClosingCalled, true);
+      expect(_testWsListener.closingCode, 234);
+      expect(_testWsListener.closingReason, 'test reason 2');
+
+      // clean up
+      await _testWsListener.destroy();
+    });
+
+    test('Receive `onClosed` event from platform', () async {
+      final _testWsListener = TestWebSocketListener();
+      MethodChannelWebSocketSupport(_testWsListener);
+
+      // action
+      // execute methodCall from platform
+      await _sendMessageFromPlatform(
+          MethodChannelWebSocketSupport.methodChannelName,
+          MethodCall('onClosed',
+              <String, Object>{'code': 345, 'reason': 'test reason 3'}));
+
+      // verify
+      expect(_testWsListener.onClosedCalled, true);
+      expect(_testWsListener.closingCode, 345);
+      expect(_testWsListener.closingReason, 'test reason 3');
+
+      // clean up
+      await _testWsListener.destroy();
+    });
+
+    test('Receive `onFailure` event from platform', () async {
+      final _testWsListener = TestWebSocketListener();
+      MethodChannelWebSocketSupport(_testWsListener);
+
+      // action
+      // execute methodCall from platform
+      await _sendMessageFromPlatform(
+          MethodChannelWebSocketSupport.methodChannelName,
+          MethodCall('onFailure', <String, Object>{
+            'throwableType': 'TestType',
+            'errorMessage': 'TestErrMsg',
+            'causeMessage': 'TestErrCause'
+          }));
+
+      // verify
+      expect(_testWsListener.onErrorCalled, true);
+      expect(_testWsListener.exception, isInstanceOf<WebSocketException>());
+      expect(_testWsListener.exception.toString(),
+          'WebSocketException[type:TestType, message:TestErrMsg, cause:TestErrCause]');
+
+      // clean up
+      await _testWsListener.destroy();
+    });
+
+    test('Receive event from platform on textEventChannel', () async {
+      final _testWsListener = TestWebSocketListener();
+      MethodChannelWebSocketSupport(_testWsListener);
+
+      // prepare
+      // text message channel mock (before we is opened)
+      final _streamController = StreamController<String>.broadcast();
+      EventChannelMock(
+        channelName: MethodChannelWebSocketSupport.textEventChannelName,
+        stream: _streamController.stream,
+      );
+
+      // open ws
+      await _sendMessageFromPlatform(
+          MethodChannelWebSocketSupport.methodChannelName,
+          MethodCall('onOpened'));
+
+      // action
+      // emit test event
+      _streamController.add('Text message 1');
+
+      // verify
+      expect(_testWsListener.webSocketConnection, isNotNull);
+      expect(await _testWsListener.textQueue.next.timeout(Duration(seconds: 1)),
+          'Text message 1');
+
+      // clean up
+      await _testWsListener.destroy();
+    });
+
+    test('Receive event from platform on byteEventChannel', () async {
+      final _testWsListener = TestWebSocketListener();
+      MethodChannelWebSocketSupport(_testWsListener);
+
+      // prepare
+      // text message channel mock (before we is opened)
+      final _streamController = StreamController<Uint8List>.broadcast();
+      EventChannelMock(
+        channelName: MethodChannelWebSocketSupport.byteEventChannelName,
+        stream: _streamController.stream,
+      );
+
+      // open ws
+      await _sendMessageFromPlatform(
+          MethodChannelWebSocketSupport.methodChannelName,
+          MethodCall('onOpened'));
+
+      // action
+      // emit test event
+      _streamController.add(Uint8List.fromList('Binary message 1'.codeUnits));
+
+      // verify
+      expect(_testWsListener.webSocketConnection, isNotNull);
+      expect(await _testWsListener.byteQueue.next.timeout(Duration(seconds: 1)),
+          'Binary message 1'.codeUnits);
+
+      // clean up
+      await _testWsListener.destroy();
+    });
+
+    test('Receive `onStringMessage` event after ws is established', () async {
+      final _testWsListener = TestWebSocketListener();
+      MethodChannelWebSocketSupport(_testWsListener);
+
+      // Arrange
+      // open ws
+      await _sendMessageFromPlatform(
+          MethodChannelWebSocketSupport.methodChannelName,
+          MethodCall('onOpened'));
+
+      // Act -> onStringMessage
+      await _sendMessageFromPlatform(
+          MethodChannelWebSocketSupport.methodChannelName,
+          MethodCall('onStringMessage', 'Fallback message 1'));
+
+      // verify
+      expect(_testWsListener.webSocketConnection, isNotNull);
+      expect(await _testWsListener.textQueue.next.timeout(Duration(seconds: 1)),
+          'Fallback message 1');
+
+      // clean up
+      await _testWsListener.destroy();
+    });
+
+    test('Receive `onByteArrayMessage` event after ws is established',
+        () async {
+      final _testWsListener = TestWebSocketListener();
+      MethodChannelWebSocketSupport(_testWsListener);
+
+      // Arrange
+      // open ws
+      await _sendMessageFromPlatform(
+          MethodChannelWebSocketSupport.methodChannelName,
+          MethodCall('onOpened'));
+
+      // Act -> onByteArrayMessage
+      await _sendMessageFromPlatform(
+          MethodChannelWebSocketSupport.methodChannelName,
+          MethodCall('onByteArrayMessage',
+              Uint8List.fromList('Fallback message 2'.codeUnits)));
+
+      // verify
+      expect(_testWsListener.webSocketConnection, isNotNull);
+      expect(await _testWsListener.byteQueue.next.timeout(Duration(seconds: 1)),
+          'Fallback message 2'.codeUnits);
+
+      // clean up
+      await _testWsListener.destroy();
+    });
+  });
+}
+
+Future<ByteData?> _sendMessageFromPlatform(
+    String channelName, MethodCall methodCall) {
+  final envelope = const StandardMethodCodec().encodeMethodCall(methodCall);
+  return TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
+      .handlePlatformMessage(channelName, envelope, (data) {});
+}

--- a/web_socket_support/web_socket_support_platform_interface/test/test_web_socket_listener.dart
+++ b/web_socket_support/web_socket_support_platform_interface/test/test_web_socket_listener.dart
@@ -1,0 +1,71 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:async/async.dart';
+import 'package:web_socket_support_platform_interface/web_socket_connection.dart';
+import 'package:web_socket_support_platform_interface/web_socket_listener.dart';
+
+class TestWebSocketListener extends WebSocketListener {
+  final _textController = StreamController<String>();
+  final _byteController = StreamController<Uint8List>();
+  late StreamQueue<String> textQueue;
+  late StreamQueue<Uint8List> byteQueue;
+  WebSocketConnection? webSocketConnection;
+  bool onClosingCalled = false;
+  bool onClosedCalled = false;
+  bool onErrorCalled = false;
+  int? closingCode;
+  String? closingReason;
+  Exception? exception;
+
+  TestWebSocketListener() {
+    textQueue = StreamQueue(_textController.stream);
+    byteQueue = StreamQueue(_byteController.stream);
+  }
+
+  @override
+  void onWsOpened(WebSocketConnection webSocketConnection) {
+    this.webSocketConnection = webSocketConnection;
+  }
+
+  @override
+  void onStringMessage(String message) {
+    _textController.add(message);
+  }
+
+  @override
+  void onByteArrayMessage(Uint8List message) {
+    _byteController.add(message);
+  }
+
+  @override
+  void onWsClosing(int code, String reason) {
+    onClosingCalled = true;
+    closingCode = code;
+    closingReason = reason;
+    _textController.close();
+    _byteController.close();
+  }
+
+  @override
+  void onWsClosed(int code, String reason) {
+    onClosedCalled = true;
+    closingCode = code;
+    closingReason = reason;
+    _textController.close();
+    _byteController.close();
+  }
+
+  @override
+  void onError(Exception e) {
+    onErrorCalled = true;
+    exception = e;
+  }
+
+  Future<void> destroy() async {
+    await textQueue.cancel();
+    await byteQueue.cancel();
+    await _textController.close();
+    await _byteController.close();
+  }
+}

--- a/web_socket_support/web_socket_support_platform_interface/test/test_web_socket_listener.dart
+++ b/web_socket_support/web_socket_support_platform_interface/test/test_web_socket_listener.dart
@@ -14,6 +14,7 @@ class TestWebSocketListener extends WebSocketListener {
   bool onClosingCalled = false;
   bool onClosedCalled = false;
   bool onErrorCalled = false;
+  final errorCompleter = Completer();
   int? closingCode;
   String? closingReason;
   Exception? exception;
@@ -60,6 +61,7 @@ class TestWebSocketListener extends WebSocketListener {
   void onError(Exception e) {
     onErrorCalled = true;
     exception = e;
+    errorCompleter.complete();
   }
 
   Future<void> destroy() async {

--- a/web_socket_support/web_socket_support_platform_interface/test/web_socket_support_platform_interface_test.dart
+++ b/web_socket_support/web_socket_support_platform_interface/test/web_socket_support_platform_interface_test.dart
@@ -1,7 +1,10 @@
+import 'dart:typed_data';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:web_socket_support_platform_interface/method_channel_web_socket_support.dart';
+import 'package:web_socket_support_platform_interface/web_socket_connection.dart';
 import 'package:web_socket_support_platform_interface/web_socket_listener.dart';
 import 'package:web_socket_support_platform_interface/web_socket_support_platform_interface.dart';
 
@@ -21,6 +24,53 @@ void main() {
         WebSocketSupportPlatform.instance =
             ImplementsWebSocketSupportPlatform();
       }, throwsA(isInstanceOf<AssertionError>()));
+    });
+
+    test(
+        '$MethodChannelWebSocketSupport dummy listener throws exception on any call',
+        () {
+      expect(
+        () =>
+            (WebSocketSupportPlatform.instance as MethodChannelWebSocketSupport)
+                .listener
+                .onByteArrayMessage(Uint8List.fromList(List.empty())),
+        throwsUnimplementedError,
+      );
+      expect(
+        () =>
+            (WebSocketSupportPlatform.instance as MethodChannelWebSocketSupport)
+                .listener
+                .onError(Exception()),
+        throwsUnimplementedError,
+      );
+      expect(
+        () =>
+            (WebSocketSupportPlatform.instance as MethodChannelWebSocketSupport)
+                .listener
+                .onStringMessage(''),
+        throwsUnimplementedError,
+      );
+      expect(
+        () =>
+            (WebSocketSupportPlatform.instance as MethodChannelWebSocketSupport)
+                .listener
+                .onWsClosed(1, ''),
+        throwsUnimplementedError,
+      );
+      expect(
+        () =>
+            (WebSocketSupportPlatform.instance as MethodChannelWebSocketSupport)
+                .listener
+                .onWsClosing(1, ''),
+        throwsUnimplementedError,
+      );
+      expect(
+        () =>
+            (WebSocketSupportPlatform.instance as MethodChannelWebSocketSupport)
+                .listener
+                .onWsOpened(WebSocketConnectionMock()),
+        throwsUnimplementedError,
+      );
     });
 
     test('Can be mocked with `implements`', () {
@@ -61,6 +111,8 @@ void main() {
     });
   });
 }
+
+class WebSocketConnectionMock extends Mock implements WebSocketConnection {}
 
 class WebSocketSupportPlatformMock extends Mock
     with MockPlatformInterfaceMixin

--- a/web_socket_support/web_socket_support_platform_interface/test/web_socket_support_platform_interface_test.dart
+++ b/web_socket_support/web_socket_support_platform_interface/test/web_socket_support_platform_interface_test.dart
@@ -1,19 +1,15 @@
-import 'dart:async';
-import 'dart:typed_data';
-
-import 'package:async/async.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:web_socket_support_platform_interface/method_channel_web_socket_support.dart';
-import 'package:web_socket_support_platform_interface/web_socket_connection.dart';
 import 'package:web_socket_support_platform_interface/web_socket_listener.dart';
-import 'package:web_socket_support_platform_interface/web_socket_options.dart';
 import 'package:web_socket_support_platform_interface/web_socket_support_platform_interface.dart';
 
+import 'test_web_socket_listener.dart';
+
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('$WebSocketSupportPlatform', () {
     test('$MethodChannelWebSocketSupport() is the default instance', () {
       expect(WebSocketSupportPlatform.instance,
@@ -36,241 +32,32 @@ void main() {
       WebSocketSupportPlatform.instance =
           ExtendsWebSocketSupportPlatform(TestWebSocketListener());
     });
-  });
 
-  group('$MethodChannelWebSocketSupport calls TO platform', () {
-    WidgetsFlutterBinding.ensureInitialized();
+    test('Default implementation of `connect` should throw unimplemented error',
+        () {
+      // Arrange
+      final webSocketSupport =
+          ExtendsWebSocketSupportPlatform(TestWebSocketListener());
 
-    //
-    // mock channels
-    MethodChannel _methodChannel;
-    EventChannel _textMessages;
-    EventChannel _byteMessages;
-    MethodChannelWebSocketSupport _webSocketSupport;
-    WebSocketConnection _webSocketConnection;
-
-    // MethodChannel calls
-    final calledMethodsLog = <MethodCall>[];
-
-    // EventChannel
-    StreamController<String> textMessagesController;
-    StreamController<Uint8List> byteMessagesController;
-
-    setUp(() {
-      // init variables
-      _methodChannel = MethodChannel('web-socket-test');
-      _textMessages = MockEventChannel();
-      _byteMessages = MockEventChannel();
-
-      _webSocketSupport = MethodChannelWebSocketSupport.private(
-          TestWebSocketListener(),
-          _methodChannel,
-          _textMessages,
-          _byteMessages);
-
-      calledMethodsLog.clear();
-      _methodChannel.setMockMethodCallHandler((MethodCall methodCall) async {
-        calledMethodsLog.add(methodCall); // add call to log
-        if (methodCall.method == 'connect') {
-          _webSocketConnection = DefaultWebSocketConnection(_methodChannel);
-        }
-      });
-
-      // text EventChannel
-      textMessagesController = StreamController<String>();
-      when(_textMessages.receiveBroadcastStream())
-          .thenAnswer((Invocation invoke) => textMessagesController.stream);
-
-      // Byte EventChannel
-      byteMessagesController = StreamController<Uint8List>();
-      when(_byteMessages.receiveBroadcastStream())
-          .thenAnswer((Invocation invoke) => byteMessagesController.stream);
-    });
-
-    tearDown(() {
-      calledMethodsLog.clear();
-      textMessagesController.close();
-      byteMessagesController.close();
-    });
-
-    test('connect and send message', () async {
-      await _webSocketSupport.connect('ws://example.com/',
-          options: WebSocketOptions(
-            autoReconnect: true,
-          ));
-      await _webSocketConnection.sendTextMessage('test-text-message');
-      await _webSocketConnection
-          .sendByteMessage(Uint8List.fromList('test-byte-message'.codeUnits));
+      // Act & Assert
       expect(
-        calledMethodsLog,
-        <Matcher>[
-          isMethodCall('connect', arguments: <String, Object>{
-            'serverUrl': 'ws://example.com/',
-            'options': {
-              'autoReconnect': true,
-              'pingInterval': 0,
-              'headers': {},
-            },
-          }),
-          isMethodCall('sendTextMessage', arguments: <String, Object>{
-            'textMessage': 'test-text-message',
-          }),
-          isMethodCall('sendByteMessage', arguments: <String, Object>{
-            'byteMessage': 'test-byte-message'.codeUnits,
-          }),
-        ],
+        () => webSocketSupport.connect('ws.test.com'),
+        throwsUnimplementedError,
       );
     });
 
-    test('disconnect', () async {
-      await _webSocketSupport.disconnect(code: 3, reason: 'test');
+    test(
+        'Default implementation of `disconnect` should throw unimplemented error',
+        () {
+      // Arrange
+      final webSocketSupport =
+          ExtendsWebSocketSupportPlatform(TestWebSocketListener());
+
+      // Act & Assert
       expect(
-        calledMethodsLog,
-        <Matcher>[
-          isMethodCall('disconnect', arguments: <String, Object>{
-            'code': 3,
-            'reason': 'test'
-          }),
-        ],
+        () => webSocketSupport.disconnect(),
+        throwsUnimplementedError,
       );
-    });
-  });
-
-  group('$MethodChannelWebSocketSupport calls FROM platform', () {
-    WidgetsFlutterBinding.ensureInitialized();
-
-    //
-    // mock channels
-    MethodChannel _methodChannel;
-    EventChannel textMessages;
-    EventChannel byteMessages;
-    MethodChannelWebSocketSupport _webSocketSupport;
-    Function methodCallFunction;
-    TestWebSocketListener _testWebSocketListener;
-
-    // EventChannel
-    StreamController<String> textMessagesController;
-    StreamController<Uint8List> byteMessagesController;
-
-    setUp(() {
-      // init variables
-      _methodChannel = MockMethodChannel();
-      textMessages = MockEventChannel();
-      byteMessages = MockEventChannel();
-
-      // MethodChannel
-      when(_methodChannel.setMethodCallHandler(any))
-          .thenAnswer((realInvocation) {
-        methodCallFunction = realInvocation.positionalArguments[0];
-      });
-
-      // text EventChannel
-      textMessagesController = StreamController<String>();
-      when(textMessages.receiveBroadcastStream())
-          .thenAnswer((Invocation invoke) => textMessagesController.stream);
-
-      // Byte EventChannel
-      byteMessagesController = StreamController<Uint8List>();
-      when(byteMessages.receiveBroadcastStream())
-          .thenAnswer((Invocation invoke) => byteMessagesController.stream);
-
-      // test web socket listener
-      _testWebSocketListener = TestWebSocketListener();
-
-      // init MethodChannelWebSocketSupport
-      _webSocketSupport = MethodChannelWebSocketSupport.private(
-          _testWebSocketListener, _methodChannel, textMessages, byteMessages);
-    });
-
-    tearDown(() {
-      textMessagesController.close();
-      byteMessagesController.close();
-      _testWebSocketListener?.onWsClosed(0, '');
-    });
-
-    test('calls receiveBroadcastStream once', () {
-      // connect
-      _webSocketSupport.connect(
-        'ws://example.com/',
-        options: WebSocketOptions(),
-      );
-
-      // verify
-      verify(textMessages.receiveBroadcastStream()).called(1);
-      verify(byteMessages.receiveBroadcastStream()).called(1);
-    });
-
-    test('onOpened', () async {
-      // connect
-      await _webSocketSupport.connect(
-        'ws://example.com/',
-        options: WebSocketOptions(),
-      );
-      methodCallFunction.call(MethodCall('onOpened'));
-
-      // verify
-      expect(_testWebSocketListener.webSocketConnection, isNotNull);
-    });
-
-    test('onClosing', () async {
-      // connect
-      await _webSocketSupport.connect(
-        'ws://example.com/',
-        options: WebSocketOptions(),
-      );
-      methodCallFunction
-          .call(MethodCall('onClosing', {'code': 13, 'reason': 'testReason1'}));
-
-      // verify
-      expect(_testWebSocketListener.onClosingCalled, true);
-      expect(_testWebSocketListener.closingCode, 13);
-      expect(_testWebSocketListener.closingReason, 'testReason1');
-    });
-
-    test('onClosed', () async {
-      // connect
-      await _webSocketSupport.connect(
-        'ws://example.com/',
-        options: WebSocketOptions(),
-      );
-      methodCallFunction
-          .call(MethodCall('onClosed', {'code': 101, 'reason': 'testReason2'}));
-
-      // verify
-      expect(_testWebSocketListener.onClosedCalled, true);
-      expect(_testWebSocketListener.closingCode, 101);
-      expect(_testWebSocketListener.closingReason, 'testReason2');
-    });
-
-    test('onTextMessage', () async {
-      // connect
-      await _webSocketSupport.connect(
-        'ws://example.com/',
-        options: WebSocketOptions(),
-      );
-      textMessagesController.add('test-text-message');
-
-      // verify
-      expect(
-          await _testWebSocketListener.textQueue.next
-              .timeout(Duration(seconds: 1)),
-          'test-text-message');
-    });
-
-    test('onByteMessage', () async {
-      // connect
-      await _webSocketSupport.connect(
-        'ws://example.com/',
-        options: WebSocketOptions(),
-      );
-      byteMessagesController
-          .add(Uint8List.fromList('test-byte-message'.codeUnits));
-
-      // verify
-      expect(
-          await _testWebSocketListener.byteQueue.next
-              .timeout(Duration(seconds: 1)),
-          'test-byte-message'.codeUnits);
     });
   });
 }
@@ -284,63 +71,4 @@ class ImplementsWebSocketSupportPlatform extends Mock
 
 class ExtendsWebSocketSupportPlatform extends WebSocketSupportPlatform {
   ExtendsWebSocketSupportPlatform(WebSocketListener listener);
-}
-
-class MockMethodChannel extends Mock implements MethodChannel {}
-
-class MockEventChannel extends Mock implements EventChannel {}
-
-class TestWebSocketListener extends WebSocketListener {
-  final _textController = StreamController<String>();
-  final _byteController = StreamController<Uint8List>();
-  StreamQueue<String> textQueue;
-  StreamQueue<Uint8List> byteQueue;
-  WebSocketConnection webSocketConnection;
-  bool onClosingCalled = false;
-  bool onClosedCalled = false;
-  int closingCode;
-  String closingReason;
-
-  TestWebSocketListener() {
-    textQueue = StreamQueue(_textController.stream);
-    byteQueue = StreamQueue(_byteController.stream);
-  }
-
-  @override
-  void onByteMessage(Uint8List message) {
-    _byteController.add(message);
-  }
-
-  @override
-  void onError(Exception exception) {
-    // TODO: implement onError
-  }
-
-  @override
-  void onTextMessage(String message) {
-    _textController.add(message);
-  }
-
-  @override
-  void onWsClosed(int code, String reason) {
-    onClosedCalled = true;
-    closingCode = code;
-    closingReason = reason;
-    _textController.close();
-    _byteController.close();
-  }
-
-  @override
-  void onWsClosing(int code, String reason) {
-    onClosingCalled = true;
-    closingCode = code;
-    closingReason = reason;
-    _textController.close();
-    _byteController.close();
-  }
-
-  @override
-  void onWsOpened(WebSocketConnection webSocketConnection) {
-    this.webSocketConnection = webSocketConnection;
-  }
 }


### PR DESCRIPTION
- new interface version released: 0.2.0
- moved to null safety (SDK >= 2.14.0)
- reworked subscription to method and event channels
- reworked unit tests since underlying API changed